### PR TITLE
Escapes found URLs to avoid XSS

### DIFF
--- a/index.php
+++ b/index.php
@@ -65,7 +65,7 @@ function processUrls($urls)
         $numMatches = count($matches[0]);
 
         for ($i = 0; $i < $numMatches; $i++) {
-          $output .= "<font color='orange'>»»</font> ".$matches[0][$i]."<br>";
+          $output .= "<font color='orange'>»»</font> ".htmlentities($matches[0][$i], ENT_QUOTES, "UTF-8")."<br>";
         }
     }
     $output = implode('<br>',array_unique(explode('<br>', $output)));


### PR DESCRIPTION
If I was a nasty person, I'd be sticking JavaScript files like this one in my pages for you to find: http://tomnomnom.uk/zseano/xss.js

The problem with that is when JS-Scan outputs the URL from that file it's not escaped :)

Bounty plz? ;)